### PR TITLE
Make db close

### DIFF
--- a/lib/database.py
+++ b/lib/database.py
@@ -37,6 +37,12 @@ class Database:
     cur = None  # the database cursor
 
     def __init__(self):
+        """
+        Constructor.
+        """
+        pass
+
+    def open(self):
         try:
             self.conn = mariadb.connect(
                 user=user,
@@ -49,6 +55,10 @@ class Database:
         except mariadb.Error as e:
             print(f'Error connecting to MariaDB platform: {e}')
         self.cur = self.conn.cursor()
+
+    def close(self):
+        self.conn.close()
+        print("Closed connection to MariaDB platform.")
 
 
 ###############################################################################

--- a/lib/player.py
+++ b/lib/player.py
@@ -67,8 +67,9 @@ and is registered with the bot.
         """
         if self.pkid is None:
             raise Exception("self.pkid is None - set it before calling this function!")
+
+        db.open()
         try:
-            db.open()
             db.cur.execute("SELECT name,discordid,steamid64 FROM players WHERE id=%s", (self.pkid,))
             for(name, discordid, steamid64) in db.cur:
                 # Debug print

--- a/lib/player.py
+++ b/lib/player.py
@@ -68,6 +68,7 @@ and is registered with the bot.
         if self.pkid is None:
             raise Exception("self.pkid is None - set it before calling this function!")
         try:
+            db.open()
             db.cur.execute("SELECT name,discordid,steamid64 FROM players WHERE id=%s", (self.pkid,))
             for(name, discordid, steamid64) in db.cur:
                 # Debug print
@@ -84,3 +85,4 @@ and is registered with the bot.
                 self.steam_id = steamid64
         except mariadb.Error as e:
             print(f"SQL error receiving player details from database: {e}")
+        db.close()

--- a/lib/session.py
+++ b/lib/session.py
@@ -64,6 +64,7 @@ class Session:
         if self.pkid is None:
             raise Exception("self.pkid is None - set it before calling this function!")
         try:
+            db.open()
             db.cur.execute("SELECT gameid,datetime,server FROM sessions WHERE id=%s", (self.pkid,))
             for(gameid, datetime, server) in db.cur:
                 # Debug print
@@ -82,3 +83,4 @@ class Session:
                 self.server = server
         except mariadb.Error as e:
             print(f"SQL error receiving player details from database: {e}")
+        db.close()

--- a/lib/session.py
+++ b/lib/session.py
@@ -63,8 +63,9 @@ class Session:
         """
         if self.pkid is None:
             raise Exception("self.pkid is None - set it before calling this function!")
+
+        db.open()
         try:
-            db.open()
             db.cur.execute("SELECT gameid,datetime,server FROM sessions WHERE id=%s", (self.pkid,))
             for(gameid, datetime, server) in db.cur:
                 # Debug print


### PR DESCRIPTION
Made the database connection open and close as required, instead of staying open forever.

Moved the db.open() call to outside of try block - fixed the mistake in my last PR which I suspect was causing the segfault.