### PR TITLE
Fixed a bug in Session's __eq__ function that caused "player_obj.sess…

### DIFF
--- a/lib/session.py
+++ b/lib/session.py
@@ -90,7 +90,7 @@ class Session:
         return hash(self.pkid)  # Yes this just returns the pkid... do I even need to hash? Dunno.
 
     def __eq__(self, other):
-        return (self.pkid) == (other.pkid)  # we're only comparing by pkid because it should be unique anyway.
+        return (self.pkid) == (other)  # we're only comparing by pkid because it should be unique anyway.
 
     def __ne__(self, other):
         # To avoid having both x==y and x!=y


### PR DESCRIPTION
…ions[int]" to fail.

It was giving the error "int has no attribute "pkid"", presumably because "other" is simply given to __eq__() as an int when we do something like player_obj.sessions[1].

I suspect that this is not the best way of doing things but this will do for now.